### PR TITLE
DRDT-72: Add fb:pages metatag

### DIFF
--- a/web/wp-content/themes/bumblebee/header.php
+++ b/web/wp-content/themes/bumblebee/header.php
@@ -10,10 +10,14 @@
  */
 
 wp_enqueue_style( 'bumblebee-style-header', get_stylesheet_directory_uri() . '/header.css', [], '1.0.2' );
+$fbid = get_theme_mod( 'fbid', false );
 ?>
 <!doctype html>
 <html <?php language_attributes(); ?> class="no-js">
 <head>
+	<?php if ( ! empty( $fbid ) ) : ?>
+		<meta property="fb:pages" content="<?php echo $fbid; ?>"/>
+	<?php endif; ?>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="profile" href="https://gmpg.org/xfn/11">


### PR DESCRIPTION
https://readersdigest.atlassian.net/browse/DRDT-72

Adds the `fb:pages` metatag reading the Facebook ID from the Customizer. It can be set using WP CLI, e.g. `wp theme mod set fbid THE_FACEBOOK_ID`.

![20190214-102419](https://user-images.githubusercontent.com/5465762/52789501-be49e780-3042-11e9-8679-f15c30140a8e.png)

At the moment there's no settings page or Customizer section to edit the value. This is documented in https://readersdigest.atlassian.net/browse/DRDT-99.